### PR TITLE
Handle scalar parameters in SM3

### DIFF
--- a/precondition/sm3.py
+++ b/precondition/sm3.py
@@ -72,6 +72,8 @@ def sm3(
     """Initialise the optimiser's state."""
 
     def _init(param):
+      # Quantization and SM3 accumulators require at least one dimension.
+      param = jnp.atleast_1d(param)
       accumulators = [jnp.zeros([s]) for s in param.shape]
       momentum = _quantize_momentum(jnp.zeros_like(param))
       return ParameterStats(accumulators, momentum)  # pytype: disable=wrong-arg-types  # numpy-scalars
@@ -108,6 +110,8 @@ def sm3(
     return all_diagonal_statistics
 
   def update_fn(updates, state, params):
+    original_updates = updates
+    updates = jax.tree.map(jnp.atleast_1d, updates)
     stats = state.stats
     if normalize_grads:
       updates = jax.tree.map(
@@ -162,7 +166,10 @@ def sm3(
     if callable(learning_rate):
       lr = learning_rate(state.count)
 
-    new_updates = jax.tree.map(lambda pg: -lr * pg, updated_momentum_with_wd)
+    new_updates = jax.tree.map(
+        lambda pg, grad: -lr * pg.reshape(grad.shape),
+        updated_momentum_with_wd,
+        original_updates)
     return new_updates, SM3State(count=state.count+1, stats=new_sm3_stats)
 
   return optax.GradientTransformation(init_fn, update_fn)  # pyrefly: ignore[bad-argument-type]

--- a/precondition/sm3_test.py
+++ b/precondition/sm3_test.py
@@ -15,6 +15,7 @@
 """Tests for distributed_shampoo."""
 
 from absl.testing import absltest
+from absl.testing import parameterized
 import chex
 import jax
 import jax.numpy as jnp
@@ -46,6 +47,71 @@ class SM3Test(chex.TestCase):
 
     updates, state = pmap_fn(jnp.array([1.0]))
     chex.assert_tree_all_finite((params, updates, state))
+
+
+class SM3ScalarTest(parameterized.TestCase):
+
+  @parameterized.product(
+      compiled=[False, True],
+      beta1=[0.0, 0.9],
+      beta2=[0.999, 1.0],
+      normalize_grads=[False, True],
+  )
+  def test_scalar_matches_length_one_parameter(
+      self, compiled, beta1, beta2, normalize_grads
+  ):
+    params = {
+        'scalar': jnp.array(2.0),
+        'vector': jnp.array([1.0, -1.0]),
+        'matrix': jnp.ones((2, 3)),
+    }
+    reference_params = dict(params, scalar=params['scalar'][None])
+    optim = sm3.sm3(
+        learning_rate=lambda step: 0.1 / (step + 1),
+        beta1=beta1,
+        beta2=beta2,
+        weight_decay=0.05,
+        normalize_grads=normalize_grads,
+    )
+    initialize = jax.jit(optim.init) if compiled else optim.init
+    update = jax.jit(optim.update) if compiled else optim.update
+    state = initialize(params)
+    reference_state = initialize(reference_params)
+    for step, value in enumerate([2.0, 0.0, -1.0, 0.5]):
+      grads = {
+          'scalar': jnp.array(value),
+          'vector': jnp.array([value, -value]),
+          'matrix': jnp.full((2, 3), value),
+      }
+      reference_grads = dict(grads, scalar=grads['scalar'][None])
+      updates, state = update(grads, state, params)
+      expected, reference_state = update(
+          reference_grads, reference_state, reference_params
+      )
+      chex.assert_tree_all_finite((updates, state))
+      chex.assert_trees_all_equal_shapes(updates, params)
+      chex.assert_trees_all_close(
+          jax.tree.map(jnp.atleast_1d, updates), expected
+      )
+      self.assertEqual(int(state.count), step + 1)
+      params = jax.tree.map(lambda p, g: p + g, params, updates)
+      reference_params = jax.tree.map(
+          lambda p, g: p + g, reference_params, expected
+      )
+
+  def test_scalar_adagrad_recurrence(self):
+    optim = sm3.sm3(0.1, beta1=0.0, beta2=1.0, diagonal_epsilon=0.25)
+    param = jnp.array(1.0)
+    state = optim.init(param)
+    accumulator = 0.0
+    for value in [2.0, 0.0, -1.0, 0.5]:
+      grad = jnp.array(value)
+      update, state = optim.update(grad, state, param)
+      accumulator += value**2
+      expected = -0.1 * value / (accumulator + 0.25) ** 0.5
+      self.assertEqual(update.shape, ())
+      self.assertAlmostEqual(float(update), expected, places=6)
+      param += update
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
SM3 cannot initialize scalar parameters because its quantization and accumulators require a nonzero rank.

Treat scalar leaves as length-one arrays internally and restore their original update shapes. Add multi-step scalar and mixed-pytree tests covering schedules, gradient normalization, weight decay, momentum and JIT.

Validation: all 21 SM3 tests pass; 17 new cases fail on unchanged upstream. Eighty non-scalar updates and states match upstream exactly. The broader SM3/tearfree run has 324 passes and two numerical-tolerance failures, both reproduced on unchanged upstream: `MomentumTest.test_wd_before_momentum1` and `OptimizerTest.test_momentum_yes_graft2`. Syntax and `git diff --check` pass.
